### PR TITLE
fix: `filterReq` crashes `send` middleware

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -69,7 +69,7 @@ export function proxy(
 
           resolver(err, ctx, next);
         } else {
-          next();
+          return next();
         }
       });
   };

--- a/test/deps.ts
+++ b/test/deps.ts
@@ -1,4 +1,4 @@
-export * as Oak from "https://deno.land/x/oak@v7.7.0/mod.ts";
+export * as Oak from "https://deno.land/x/oak@v7.3.0/mod.ts";
 export * as Opine from "https://deno.land/x/opine@1.3.3/mod.ts";
 export { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 export { superoak } from "https://deno.land/x/superoak@4.2.0/mod.ts";

--- a/test/deps.ts
+++ b/test/deps.ts
@@ -1,4 +1,4 @@
-export * as Oak from "https://deno.land/x/oak@v7.3.0/mod.ts";
+export * as Oak from "https://deno.land/x/oak@v7.7.0/mod.ts";
 export * as Opine from "https://deno.land/x/opine@1.3.3/mod.ts";
 export { expect } from "https://deno.land/x/expect@v0.2.6/mod.ts";
 export { superoak } from "https://deno.land/x/superoak@4.2.0/mod.ts";

--- a/test/filterReq.test.ts
+++ b/test/filterReq.test.ts
@@ -18,9 +18,12 @@ function nextMethod(ctx: any, next: any) {
   ctx.response.body = "Client Application";
 }
 
-async function nextMethodThatReliesOnPrivateStatesOfOak(ctx: Oak.Context, next: any) {
-    await ctx.send({root: `${Deno.cwd()}/test`, index: "index.test.html"});
-    ctx.response.status = 201;
+async function nextMethodThatReliesOnPrivateStatesOfOak(
+  ctx: Oak.Context,
+  next: any,
+) {
+  await ctx.send({ root: `${Deno.cwd()}/test`, index: "index.test.html" });
+  ctx.response.status = 201;
 }
 
 describe("filterReq", () => {

--- a/test/filterReq.test.ts
+++ b/test/filterReq.test.ts
@@ -18,6 +18,11 @@ function nextMethod(ctx: any, next: any) {
   ctx.response.body = "Client Application";
 }
 
+async function nextMethodThatReliesOnPrivateStatesOfOak(ctx: Oak.Context, next: any) {
+    await ctx.send({root: `${Deno.cwd()}/test`, index: "index.test.html"});
+    ctx.response.status = 201;
+}
+
 describe("filterReq", () => {
   it("should continue route processing when the filter function returns false (i.e. don't filter)", async (
     done,
@@ -96,6 +101,94 @@ describe("filterReq", () => {
       filterReq: () => Promise.resolve(true),
     }));
     app.use(nextMethod);
+
+    const request = await superoak(app);
+
+    request.get("/")
+      .expect(201)
+      .end((err) => {
+        proxyServer.close();
+        done(err);
+      });
+  });
+
+  it("should continue route processing when the filter function returns false (i.e. don't filter and don't serve static files)", async (
+    done,
+  ) => {
+    const proxyServer = proxyTarget({ handlers: proxyRouteFn });
+    const proxyPort = (proxyServer.listener.addr as Deno.NetAddr).port;
+
+    const app = new Application();
+    app.use(proxy(`http://localhost:${proxyPort}`, {
+      filterReq: () => false,
+    }));
+    app.use(nextMethodThatReliesOnPrivateStatesOfOak);
+
+    const request = await superoak(app);
+
+    request.get("/")
+      .expect(200)
+      .end((err) => {
+        proxyServer.close();
+        done(err);
+      });
+  });
+
+  it("should stop route processing when the filter function returns true (i.e. filter and serve static files)", async (
+    done,
+  ) => {
+    const proxyServer = proxyTarget({ handlers: proxyRouteFn });
+    const proxyPort = (proxyServer.listener.addr as Deno.NetAddr).port;
+
+    const app = new Application();
+    app.use(proxy(`http://localhost:${proxyPort}`, {
+      filterReq: () => true,
+    }));
+    app.use(nextMethodThatReliesOnPrivateStatesOfOak);
+
+    const request = await superoak(app);
+
+    request.get("/")
+      .expect(201)
+      .end((err) => {
+        proxyServer.close();
+        done(err);
+      });
+  });
+
+  it("should continue route processing when the filter function returns Promise<false> (i.e. don't filter and don't serve static files)", async (
+    done,
+  ) => {
+    const proxyServer = proxyTarget({ handlers: proxyRouteFn });
+    const proxyPort = (proxyServer.listener.addr as Deno.NetAddr).port;
+
+    const app = new Application();
+    app.use(proxy(`http://localhost:${proxyPort}`, {
+      filterReq: () => Promise.resolve(false),
+    }));
+    app.use(nextMethodThatReliesOnPrivateStatesOfOak);
+
+    const request = await superoak(app);
+
+    request.get("/")
+      .expect(200)
+      .end((err) => {
+        proxyServer.close();
+        done(err);
+      });
+  });
+
+  it("should stop route processing when the filter function returns Promise<true> (i.e. filter and serve static files)", async (
+    done,
+  ) => {
+    const proxyServer = proxyTarget({ handlers: proxyRouteFn });
+    const proxyPort = (proxyServer.listener.addr as Deno.NetAddr).port;
+
+    const app = new Application();
+    app.use(proxy(`http://localhost:${proxyPort}`, {
+      filterReq: () => Promise.resolve(true),
+    }));
+    app.use(nextMethodThatReliesOnPrivateStatesOfOak);
 
     const request = await superoak(app);
 

--- a/test/index.test.html
+++ b/test/index.test.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html>
+    <body></body>
+</html>


### PR DESCRIPTION
# Issue

fix: `filterReq` crashes `send` middleware

## Details

When `filterReq` return `false`, the middleware will crash with this error after it attempts to call `next` to static serving middleware such as `send`
 
> error: Uncaught Error: The response is not writable.
      throw new Error("The response is not writable.");

Must `return` the promise yield by `next` when invoking from within a promise chain. This is similar to [Getting "The response is not writable."](https://github.com/oakserver/oak/issues/148)

## CheckList

- [ ] PR starts with [#_ISSUE_ID_].
- [x] Has been tested (where required) before merge to main.
